### PR TITLE
Promises patch v8

### DIFF
--- a/deps/v8/include/v8.h
+++ b/deps/v8/include/v8.h
@@ -5260,6 +5260,8 @@ class V8_EXPORT PersistentHandleVisitor {  // NOLINT
  */
 class V8_EXPORT Isolate {
  public:
+  class MicrotaskQueue;
+
   /**
    * Initial configuration parameters for a new Isolate.
    */
@@ -5271,7 +5273,8 @@ class V8_EXPORT Isolate {
           counter_lookup_callback(NULL),
           create_histogram_callback(NULL),
           add_histogram_sample_callback(NULL),
-          array_buffer_allocator(NULL) {}
+          array_buffer_allocator(NULL),
+          microtask_queue(NULL) {}
 
     /**
      * The optional entry_hook allows the host application to provide the
@@ -5319,6 +5322,11 @@ class V8_EXPORT Isolate {
      * store of ArrayBuffers.
      */
     ArrayBuffer::Allocator* array_buffer_allocator;
+
+    /**
+     * The MicrotaskQueue implementation to use.
+     */
+    MicrotaskQueue* microtask_queue;
   };
 
 
@@ -5380,6 +5388,18 @@ class V8_EXPORT Isolate {
     AllowJavascriptExecutionScope(const AllowJavascriptExecutionScope&);
     AllowJavascriptExecutionScope& operator=(
         const AllowJavascriptExecutionScope&);
+  };
+
+  /**
+   *
+   *
+   */
+  class V8_EXPORT MicrotaskQueue {
+    public:
+      virtual ~MicrotaskQueue() {};
+      virtual void Enqueue(Local<Function>) = 0;
+      virtual void Enqueue(MicrotaskCallback, void*) = 0;
+      virtual void Run() = 0;
   };
 
   /**

--- a/deps/v8/src/isolate.cc
+++ b/deps/v8/src/isolate.cc
@@ -2654,13 +2654,9 @@ void Isolate::ExtEnqueueMicrotask(MicrotaskCallback microtask, void* data) {
 
 
 void Isolate::EnqueueMicrotask(Handle<Object> microtask) {
-  if (microtask->IsJSFunction()) {
-    microtask_queue()->Enqueue(
-        Utils::ToLocal(Handle<JSObject>::cast(microtask)).As<Function>());
-  } else {
-    // panic?
-    abort();
-  }
+  DCHECK(microtask->IsJSFunction());
+  microtask_queue()->Enqueue(
+      Utils::ToLocal(Handle<JSObject>::cast(microtask)).As<Function>());
 }
 
 

--- a/src/env.h
+++ b/src/env.h
@@ -138,6 +138,7 @@ namespace node {
   V(name_string, "name")                                                      \
   V(need_imm_cb_string, "_needImmediateCallback")                             \
   V(netmask_string, "netmask")                                                \
+  V(nexttick_string, "nextTick")                                              \
   V(nice_string, "nice")                                                      \
   V(nlink_string, "nlink")                                                    \
   V(npn_buffer_string, "npnBuffer")                                           \

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -238,6 +238,20 @@ class ArrayBufferAllocator : public v8::ArrayBuffer::Allocator {
   Environment* env_;
 };
 
+class MicrotaskQueue : public v8::Isolate::MicrotaskQueue {
+ public:
+  MicrotaskQueue() : env_(nullptr) { }
+  virtual ~MicrotaskQueue() { }
+  inline void set_env(Environment* env) { env_ = env; }
+
+  virtual void Enqueue(v8::Local<v8::Function>);
+  virtual void Enqueue(v8::MicrotaskCallback, void*);
+  virtual void Run();
+
+ private:
+  Environment* env_;
+};
+
 enum NodeInstanceType { MAIN, WORKER };
 
 class NodeInstanceData {


### PR DESCRIPTION
This is a WIP, intended to open the discussion on how to proceed with a pluggable MicrotaskQueue. My C++ is rusty, and I've probably made mistakes WRT to not implementing the appropriate `HandleScope`s — please point these out! Also missing is a mechanism for `delete`-ing the `MicrotaskQueue` on Isolate exit. This approach extends the split between `EnqueueMicrotask(MicrotaskCallback, void*)` and `EnqueueMicrotask(Local<Function>)` from the public `Isolate` to the private `Isolate`.

I've included an **example** commit that shows how Node could consume this API, by placing microtasks into the `nextTick` queue. Ultimately we _may not_ unify the queues, but we would make use of this API to allow us to use `MakeCallback` when entering JS from C++ at top-of-event-loop.
